### PR TITLE
Add address capability to v1 API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is the [Noonlight](https://noonlight.com) integration for HomeAssistant.
 
+This particular version is a fork of the official version on the [Konnected.io repository](https://github.com/konnected-io/noonlight-hass).  This adds address information using the v1 API.  There is another fork on [On3man's Github](https://github.com/0n3man/noonlight-hass) that already does this and more, but apparently uses the v2 API that may not be appropriate for this usage ([see this message in the pull request](https://github.com/konnected-io/noonlight-hass/pull/5#issuecomment-854991868)).  So far as I know, On3man's repository 
+
 [Noonlight](https://noonlight.com) connects your smart home to local emergency services to help keep you safe in case of a break-in, fire, or medical emergency.
 
 <p class='note info'>
@@ -51,6 +53,28 @@ noonlight:
 * `secret`: A secret key associated with your id
 * `api_endpoint`: The Noonlight API endpoint used when creating an alarm
 * `token_endpoint`: The OAuth endpoint used to refresh your Noonlight auth token (hosted by [Konnected](https://konnected.io))
+
+To use the address functionality, you need to add some additional items to the above entry.  If you don't populate these, the base lat/long-based functionality will still be used.
+
+```yaml
+# Example configuration.yaml entry
+noonlight:
+  id: NOONLIGHT_ID
+  secret: NOONLIGHT_SECRET
+  api_endpoint: https://api.noonlight.com/platform/v1
+  token_endpoint: https://noonlight.konnected.io/ha/token
+  line1: '123 Street Address'
+  line2: 'Apt X'
+  city: 'Anytown'
+  state: 'WA'
+  zip: '98100'
+```
+
+* `line1`: Street address
+* `line2`: Apartment, suite, etc. (optional)
+* `city`: City/town name
+* `state`: Two-letter state abbreviation
+* `zip`: Zip code
 
 ## Automation Examples
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the [Noonlight](https://noonlight.com) integration for HomeAssistant.
 
-This particular version is a fork of the official version on the [Konnected.io repository](https://github.com/konnected-io/noonlight-hass).  This adds address information using the v1 API.  There is another fork on [On3man's Github](https://github.com/0n3man/noonlight-hass) that already does this and more, but apparently uses the v2 API that may not be appropriate for this usage ([see this message in the pull request](https://github.com/konnected-io/noonlight-hass/pull/5#issuecomment-854991868)).  So far as I know, On3man's repository 
+This particular version is a fork of the official version on the [Konnected.io repository](https://github.com/konnected-io/noonlight-hass).  This adds address information using the v1 API.  There is another fork on [On3man's Github](https://github.com/0n3man/noonlight-hass) that already does this and more, but apparently uses the v2 API that may not be appropriate for this usage ([see this message in the pull request](https://github.com/konnected-io/noonlight-hass/pull/5#issuecomment-854991868)).  So far as I know, On3man's repository works fine, this is just an attempt to make something that may be "more compliant".
 
 [Noonlight](https://noonlight.com) connects your smart home to local emergency services to help keep you safe in case of a break-in, fire, or medical emergency.
 

--- a/custom_components/noonlight/__init__.py
+++ b/custom_components/noonlight/__init__.py
@@ -32,6 +32,11 @@ TOKEN_CHECK_INTERVAL = timedelta(minutes=15)
 CONF_SECRET = 'secret'
 CONF_API_ENDPOINT = 'api_endpoint'
 CONF_TOKEN_ENDPOINT = 'token_endpoint'
+CONF_LINE1 = 'line1'
+CONF_LINE2 = 'line2'
+CONF_CITY = 'city'
+CONF_STATE = 'state'
+CONF_ZIP = 'zip'
 
 CONST_ALARM_STATUS_ACTIVE = 'ACTIVE'
 CONST_ALARM_STATUS_CANCELED = 'CANCELED'
@@ -50,6 +55,11 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Required(CONF_SECRET): cv.string,
         vol.Required(CONF_API_ENDPOINT): cv.string,
         vol.Required(CONF_TOKEN_ENDPOINT): cv.string,
+        vol.Optional(CONF_LINE1): cv.string,
+        vol.Optional(CONF_LINE2): cv.string,
+        vol.Optional(CONF_CITY): cv.string,
+        vol.Optional(CONF_STATE): cv.string,
+        vol.Optional(CONF_ZIP): cv.string,
         vol.Inclusive(CONF_LATITUDE, 'coordinates',
                       'Include both latitude and longitude'): cv.latitude,
         vol.Inclusive(CONF_LONGITUDE, 'coordinates',
@@ -142,6 +152,13 @@ class NoonlightIntegration():
         self.client = nl.NoonlightClient(token=self.access_token,
                                          session=self._websession)
         self.client.set_base_url(self.config[CONF_API_ENDPOINT])
+        
+        #Add address portions, if exist
+        self.addline1 = self.config.get(CONF_LINE1,'')
+        self.addline2 = self.config.get(CONF_LINE2,'')
+        self.addcity = self.config.get(CONF_CITY,'')
+        self.addstate = self.config.get(CONF_STATE,'')
+        self.addzip = self.config.get(CONF_ZIP,'')
 
     @property
     def latitude(self):
@@ -242,6 +259,16 @@ class NoonlightIntegration():
                         'accuracy': 5
                     }
                 }
+
+                if len(self.addline1) > 0:
+                    alarm_body['location.address'] = {
+                            'line1': self.addline1,
+                            'city': self.addcity,
+                            'state': self.addstate,
+                            'zip': self.addzip
+                        }
+                    if len(self.addline2) > 0:
+                        alarm_body['location.address']['line2'] = self.addline2
                 if len(services) > 0:
                     alarm_body['services'] = services
                 self._alarm = await self.client.create_alarm(

--- a/custom_components/noonlight/__init__.py
+++ b/custom_components/noonlight/__init__.py
@@ -252,23 +252,25 @@ class NoonlightIntegration():
                 services[alarm_type] = True
         if self._alarm is None:
             try:
-                alarm_body = {
-                    'location.coordinates': {
-                        'lat': self.latitude,
-                        'lng': self.longitude,
-                        'accuracy': 5
-                    }
-                }
-
                 if len(self.addline1) > 0:
-                    alarm_body['location.address'] = {
+                    alarm_body = {
+                        'location.address': {
                             'line1': self.addline1,
                             'city': self.addcity,
                             'state': self.addstate,
                             'zip': self.addzip
                         }
+                    }
                     if len(self.addline2) > 0:
                         alarm_body['location.address']['line2'] = self.addline2
+                else:
+                    alarm_body = {
+                        'location.coordinates': {
+                            'lat': self.latitude,
+                            'lng': self.longitude,
+                            'accuracy': 5
+                        }
+                    }
                 if len(services) > 0:
                     alarm_body['services'] = services
                 self._alarm = await self.client.create_alarm(

--- a/custom_components/noonlight/manifest.json
+++ b/custom_components/noonlight/manifest.json
@@ -2,7 +2,7 @@
   "domain": "noonlight",
   "name": "Noonlight",
   "version": "1.0.2",
-  "documentation": "https://github.com/konnected-io/noonlight-hass",
+  "documentation": "https://github.com/cfodder2000/noonlight-hass",
   "requirements": [
     "noonlight==0.1.1"
   ],

--- a/custom_components/noonlight/manifest.json
+++ b/custom_components/noonlight/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "noonlight",
   "name": "Noonlight",
-  "version": "1.0.2",
+  "version": "1.0.2.1",
   "documentation": "https://github.com/cfodder2000/noonlight-hass",
   "requirements": [
     "noonlight==0.1.1"

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-    "name": "Noonlight - Alarm Monitoring",
+    "name": "Noonlight - Alarm Monitoring - Fork",
     "render_readme": true,
     "country": "US",
     "domains": ["switch"],


### PR DESCRIPTION
Adds in the address payload for alarm calls using the v1 API, since that appears to be preferred based on [this message](https://github.com/konnected-io/noonlight-hass/pull/5#issuecomment-854991868).

Verified the address gets passed to Noonlight with the populated information.  It still requires a manual configuration.yaml edit, but since you have to paste in the Noonlight key regardless, that seems pretty trivial of a step.